### PR TITLE
Allow widgets for fab button design

### DIFF
--- a/lib/fab_circular_menu.dart
+++ b/lib/fab_circular_menu.dart
@@ -17,8 +17,8 @@ class FabCircularMenu extends StatefulWidget {
   final Color fabColor;
   final Color fabOpenColor;
   final Color fabCloseColor;
-  final Icon fabOpenIcon;
-  final Icon fabCloseIcon;
+  final Widget fabOpenIcon;
+  final Widget fabCloseIcon;
   final EdgeInsets fabMargin;
   final Duration animationDuration;
   final Curve animationCurve;


### PR DESCRIPTION
Instead of restricting the fabOpenIcon and fabCloseIcon to only except Icon (subclass of Widget) instances, I extended the setup to allow general Widget instances.