### PR TITLE
Fixes #14 and #26 and #38

### DIFF
--- a/lib/fab_circular_menu.dart
+++ b/lib/fab_circular_menu.dart
@@ -53,7 +53,7 @@ class FabCircularMenu extends StatefulWidget {
 }
 
 class FabCircularMenuState extends State<FabCircularMenu>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
   late double _screenWidth;
   late double _screenHeight;
   late double _marginH;
@@ -85,6 +85,7 @@ class FabCircularMenuState extends State<FabCircularMenu>
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
 
     _animationController =
         AnimationController(duration: widget.animationDuration, vsync: this);
@@ -111,7 +112,16 @@ class FabCircularMenuState extends State<FabCircularMenu>
   @override
   void dispose() {
     _animationController.dispose();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    _calculateProps();
+    if (isOpen) {
+      close();
+    }
   }
 
   @override

--- a/lib/fab_circular_menu.dart
+++ b/lib/fab_circular_menu.dart
@@ -136,24 +136,19 @@ class FabCircularMenuState extends State<FabCircularMenu>
         alignment: widget.alignment,
         children: <Widget>[
           // Ring
-          Transform(
-            transform: Matrix4.translationValues(
-              _translationX,
-              _translationY,
-              0.0,
-            )..scale(_scaleAnimation.value),
-            alignment: FractionalOffset.center,
-            child: OverflowBox(
-              maxWidth: _ringDiameter,
-              maxHeight: _ringDiameter,
+          OverflowBox(
+            maxWidth: _ringDiameter,
+            maxHeight: _ringDiameter,
+            child: Transform(
+              transform:
+                  Matrix4.translationValues(_translationX, _translationY, 0.0)
+                    ..scale(_scaleAnimation.value),
+              alignment: FractionalOffset.center,
               child: Container(
                 width: _ringDiameter,
                 height: _ringDiameter,
                 child: CustomPaint(
-                  painter: _RingPainter(
-                    width: _ringWidth,
-                    color: _ringColor,
-                  ),
+                  painter: _RingPainter(width: _ringWidth, color: _ringColor),
                   child: _scaleAnimation.value == 1.0
                       ? Transform.rotate(
                           angle: (2 * pi) *

--- a/lib/fab_circular_menu.dart
+++ b/lib/fab_circular_menu.dart
@@ -131,7 +131,11 @@ class FabCircularMenuState extends State<FabCircularMenu>
     return Container(
       margin: widget.fabMargin,
       // Removes the default FAB margin
-      transform: Matrix4.translationValues(16.0, 16.0, 0.0),
+      transform: Matrix4.translationValues(
+        16.0 * _directionX,
+        16.0 * _directionY,
+        0.0,
+      ),
       child: Stack(
         alignment: widget.alignment,
         children: <Widget>[


### PR DESCRIPTION
Regarding #14: swapping the `OverflowBox` and the `Translation` + scale transformation seems to help.
Regarding #26: we just need to multiply the margin values by -1 or 1 based on where the menu is. Those factors are already available in the `_directionX` and `_directionY` variables.
Regarding #38: using `WidgetsBindingObserver`'s `didChangeMetrics` callback we call `_calculateProps()` and also `close()` if the menu is open.